### PR TITLE
VS2010 Compilation errors and Equality/HashCode fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj
 *.pidb
 *.userprefs
 *.suo
+TestResults/

--- a/GameMathTests/GameMathTests.csproj
+++ b/GameMathTests/GameMathTests.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{8C447CE8-3234-4F00-A88F-555656FB231E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GameMathTests</RootNamespace>
+    <AssemblyName>GameMathTests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="QuaternionTests.cs" />
+    <Compile Include="Vector4Tests.cs" />
+    <Compile Include="Vector3Tests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Vector2Tests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mono.GameMath\Mono.GameMath.csproj">
+      <Project>{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}</Project>
+      <Name>Mono.GameMath</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/GameMathTests/Properties/AssemblyInfo.cs
+++ b/GameMathTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GameMathTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("GameMathTests")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2011")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a35f57db-3249-42e7-a944-b5166b4392cf")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/GameMathTests/QuaternionTests.cs
+++ b/GameMathTests/QuaternionTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mono.GameMath;
+
+namespace GameMathTests
+{
+	[TestClass]
+	public class QuaternionTests
+	{
+		public Quaternion Zero { get { return new Quaternion(); } }
+		public Quaternion UnitX { get { return new Quaternion(1, 0, 0, 0); } }
+		public Quaternion UnitY { get { return new Quaternion(0, 1, 0, 0); } }
+		public Quaternion UnitZ { get { return new Quaternion(0, 0, 1, 0); } }
+		public Quaternion UnitW { get { return new Quaternion(0, 0, 0, 1); } }
+
+
+		[TestMethod]
+		public void NaNEquality()
+		{
+			Quaternion nanQuat = new Quaternion(float.NaN, float.NaN, float.NaN, float.NaN);
+			Assert.IsFalse(nanQuat == nanQuat);
+			Assert.IsTrue(nanQuat != nanQuat);
+			Assert.IsTrue(nanQuat.Equals(nanQuat));
+		}
+
+		[TestMethod]
+		public void SimpleEquality()
+		{
+			Assert.IsTrue(Zero == Zero);
+			Assert.IsFalse(Zero != Zero);
+
+			Assert.IsFalse(Zero == UnitX);
+			Assert.IsFalse(Zero == UnitY);
+			Assert.IsFalse(Zero == UnitZ);
+			Assert.IsFalse(Zero == UnitW);
+
+			Assert.IsTrue(Zero.Equals(Zero));
+			Assert.IsTrue(UnitX.Equals(UnitX));
+			Assert.IsTrue(UnitY.Equals(UnitY));
+			Assert.IsTrue(UnitZ.Equals(UnitZ));
+			Assert.IsTrue(UnitW.Equals(UnitW));
+
+			Assert.IsFalse(Zero.Equals(UnitX));
+			Assert.IsFalse(Zero.Equals(UnitY));
+			Assert.IsFalse(Zero.Equals(UnitZ));
+			Assert.IsFalse(Zero.Equals(UnitW));
+		}
+
+		[TestMethod]
+		public void GoodHashCode()
+		{
+			Assert.IsTrue(UnitX.GetHashCode() != UnitY.GetHashCode());
+
+			Assert.IsTrue(Zero.GetHashCode() != UnitX.GetHashCode());
+			Assert.IsTrue(Zero.GetHashCode() != UnitY.GetHashCode());
+			Assert.IsTrue(Zero.GetHashCode() != UnitZ.GetHashCode());
+			Assert.IsTrue(Zero.GetHashCode() != UnitW.GetHashCode());
+		}
+	}
+}

--- a/GameMathTests/Vector2Tests.cs
+++ b/GameMathTests/Vector2Tests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mono.GameMath;
+
+namespace GameMathTests
+{
+	[TestClass]
+	public class Vector2Tests
+	{
+		[TestMethod]
+		public void NaNEquality()
+		{
+			Vector2 nanVec = new Vector2(float.NaN, float.NaN);
+			Assert.IsFalse(nanVec == nanVec);
+			Assert.IsTrue(nanVec != nanVec);
+			Assert.IsTrue(nanVec.Equals(nanVec));
+		}
+
+		[TestMethod]
+		public void SimpleEquality()
+		{
+			Assert.IsTrue(Vector2.Zero == Vector2.Zero);
+			Assert.IsFalse(Vector2.Zero != Vector2.Zero);
+
+			Assert.IsFalse(Vector2.Zero == Vector2.UnitX);
+			Assert.IsFalse(Vector2.Zero == Vector2.UnitY);
+
+			Assert.IsTrue(Vector2.Zero.Equals(Vector2.Zero));
+			Assert.IsTrue(Vector2.UnitX.Equals(Vector2.UnitX));
+			Assert.IsTrue(Vector2.UnitY.Equals(Vector2.UnitY));
+
+			Assert.IsFalse(Vector2.Zero.Equals(Vector2.UnitX));
+			Assert.IsFalse(Vector2.Zero.Equals(Vector2.UnitY));
+		}
+
+		[TestMethod]
+		public void GoodHashCode()
+		{
+			Assert.IsTrue(Vector2.UnitX.GetHashCode() != Vector2.UnitY.GetHashCode());
+			Assert.IsTrue(Vector2.Zero.GetHashCode() != Vector2.UnitX.GetHashCode());
+			Assert.IsTrue(Vector2.Zero.GetHashCode() != Vector2.UnitY.GetHashCode());
+		}
+	}
+}

--- a/GameMathTests/Vector3Tests.cs
+++ b/GameMathTests/Vector3Tests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mono.GameMath;
+
+namespace GameMathTests
+{
+	[TestClass]
+	public class Vector3Tests
+	{
+		[TestMethod]
+		public void NaNEquality()
+		{
+			Vector3 nanVec = new Vector3(float.NaN, float.NaN, float.NaN);
+			Assert.IsFalse(nanVec == nanVec);
+			Assert.IsTrue(nanVec != nanVec);
+			Assert.IsTrue(nanVec.Equals(nanVec));
+		}
+
+		[TestMethod]
+		public void SimpleEquality()
+		{
+			Assert.IsTrue(Vector3.Zero == Vector3.Zero);
+			Assert.IsFalse(Vector3.Zero != Vector3.Zero);
+
+			Assert.IsFalse(Vector3.Zero == Vector3.UnitX);
+			Assert.IsFalse(Vector3.Zero == Vector3.UnitY);
+			Assert.IsFalse(Vector3.Zero == Vector3.UnitZ);
+
+			Assert.IsTrue(Vector3.Zero.Equals(Vector3.Zero));
+			Assert.IsTrue(Vector3.UnitX.Equals(Vector3.UnitX));
+			Assert.IsTrue(Vector3.UnitY.Equals(Vector3.UnitY));
+			Assert.IsTrue(Vector3.UnitZ.Equals(Vector3.UnitZ));
+
+			Assert.IsFalse(Vector3.Zero.Equals(Vector3.UnitX));
+			Assert.IsFalse(Vector3.Zero.Equals(Vector3.UnitY));
+			Assert.IsFalse(Vector3.Zero.Equals(Vector3.UnitZ));
+		}
+
+		[TestMethod]
+		public void GoodHashCode()
+		{
+			Assert.IsTrue(Vector3.UnitX.GetHashCode() != Vector3.UnitY.GetHashCode());
+
+			Assert.IsTrue(Vector3.Zero.GetHashCode() != Vector3.UnitX.GetHashCode());
+			Assert.IsTrue(Vector3.Zero.GetHashCode() != Vector3.UnitY.GetHashCode());
+			Assert.IsTrue(Vector3.Zero.GetHashCode() != Vector3.UnitZ.GetHashCode());
+		}
+	}
+}

--- a/GameMathTests/Vector4Tests.cs
+++ b/GameMathTests/Vector4Tests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mono.GameMath;
+
+namespace GameMathTests
+{
+	[TestClass]
+	public class Vector4Tests
+	{
+		[TestMethod]
+		public void NaNEquality()
+		{
+			Vector4 nanVec = new Vector4(float.NaN, float.NaN, float.NaN, float.NaN);
+			Assert.IsFalse(nanVec == nanVec);
+			Assert.IsTrue(nanVec != nanVec);
+			Assert.IsTrue(nanVec.Equals(nanVec));
+		}
+
+		[TestMethod]
+		public void SimpleEquality()
+		{
+			Assert.IsTrue(Vector4.Zero == Vector4.Zero);
+			Assert.IsFalse(Vector4.Zero != Vector4.Zero);
+
+			Assert.IsFalse(Vector4.Zero == Vector4.UnitX);
+			Assert.IsFalse(Vector4.Zero == Vector4.UnitY);
+			Assert.IsFalse(Vector4.Zero == Vector4.UnitZ);
+			Assert.IsFalse(Vector4.Zero == Vector4.UnitW);
+
+			Assert.IsTrue(Vector4.Zero.Equals(Vector4.Zero));
+			Assert.IsTrue(Vector4.UnitX.Equals(Vector4.UnitX));
+			Assert.IsTrue(Vector4.UnitY.Equals(Vector4.UnitY));
+			Assert.IsTrue(Vector4.UnitZ.Equals(Vector4.UnitZ));
+			Assert.IsTrue(Vector4.UnitW.Equals(Vector4.UnitW));
+
+			Assert.IsFalse(Vector4.Zero.Equals(Vector4.UnitX));
+			Assert.IsFalse(Vector4.Zero.Equals(Vector4.UnitY));
+			Assert.IsFalse(Vector4.Zero.Equals(Vector4.UnitZ));
+			Assert.IsFalse(Vector4.Zero.Equals(Vector4.UnitW));
+		}
+
+		[TestMethod]
+		public void GoodHashCode()
+		{
+			Assert.IsTrue(Vector4.UnitX.GetHashCode() != Vector4.UnitY.GetHashCode());
+
+			Assert.IsTrue(Vector4.Zero.GetHashCode() != Vector4.UnitX.GetHashCode());
+			Assert.IsTrue(Vector4.Zero.GetHashCode() != Vector4.UnitY.GetHashCode());
+			Assert.IsTrue(Vector4.Zero.GetHashCode() != Vector4.UnitZ.GetHashCode());
+			Assert.IsTrue(Vector4.Zero.GetHashCode() != Vector4.UnitW.GetHashCode());
+		}
+	}
+}

--- a/Mono.GameMath.sln
+++ b/Mono.GameMath.sln
@@ -5,15 +5,45 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.GameMath", "Mono.GameM
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmark", "Benchmark\Benchmark.csproj", "{5A022A72-8858-4BCB-8380-7522C35E0006}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameMathTests", "GameMathTests\GameMathTests.csproj", "{8C447CE8-3234-4F00-A88F-555656FB231E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D2AFD0B7-D76C-40B0-8272-EF55E08E5855}"
+	ProjectSection(SolutionItems) = preProject
+		Local.testsettings = Local.testsettings
+		Mono.GameMath.vsmdi = Mono.GameMath.vsmdi
+		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
+	EndProjectSection
+EndProject
 Global
+	GlobalSection(TestCaseManagementSettings) = postSolution
+		CategoryFile = Mono.GameMath.vsmdi
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 		Safe|Any CPU = Safe|Any CPU
-		Unsafe|Any CPU = Unsafe|Any CPU
-		Simd|Any CPU = Simd|Any CPU
-		Xna|Any CPU = Xna|Any CPU
 		SafeX86|Any CPU = SafeX86|Any CPU
+		Simd|Any CPU = Simd|Any CPU
+		Unsafe|Any CPU = Unsafe|Any CPU
+		Xna|Any CPU = Xna|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Debug|Any CPU.ActiveCfg = Simd|Any CPU
+		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Debug|Any CPU.Build.0 = Simd|Any CPU
+		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Release|Any CPU.ActiveCfg = Simd|Any CPU
+		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Release|Any CPU.Build.0 = Simd|Any CPU
+		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Safe|Any CPU.ActiveCfg = Safe|Any CPU
+		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Safe|Any CPU.Build.0 = Safe|Any CPU
+		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.SafeX86|Any CPU.ActiveCfg = Safe|Any CPU
+		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Simd|Any CPU.ActiveCfg = Simd|Any CPU
+		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Simd|Any CPU.Build.0 = Simd|Any CPU
+		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Unsafe|Any CPU.ActiveCfg = Unsafe|Any CPU
+		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Unsafe|Any CPU.Build.0 = Unsafe|Any CPU
+		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Xna|Any CPU.ActiveCfg = Safe|Any CPU
+		{5A022A72-8858-4BCB-8380-7522C35E0006}.Debug|Any CPU.ActiveCfg = SafeX86|Any CPU
+		{5A022A72-8858-4BCB-8380-7522C35E0006}.Debug|Any CPU.Build.0 = SafeX86|Any CPU
+		{5A022A72-8858-4BCB-8380-7522C35E0006}.Release|Any CPU.ActiveCfg = SafeX86|Any CPU
+		{5A022A72-8858-4BCB-8380-7522C35E0006}.Release|Any CPU.Build.0 = SafeX86|Any CPU
 		{5A022A72-8858-4BCB-8380-7522C35E0006}.Safe|Any CPU.ActiveCfg = Safe|Any CPU
 		{5A022A72-8858-4BCB-8380-7522C35E0006}.Safe|Any CPU.Build.0 = Safe|Any CPU
 		{5A022A72-8858-4BCB-8380-7522C35E0006}.SafeX86|Any CPU.ActiveCfg = SafeX86|Any CPU
@@ -24,14 +54,23 @@ Global
 		{5A022A72-8858-4BCB-8380-7522C35E0006}.Unsafe|Any CPU.Build.0 = Unsafe|Any CPU
 		{5A022A72-8858-4BCB-8380-7522C35E0006}.Xna|Any CPU.ActiveCfg = Xna|Any CPU
 		{5A022A72-8858-4BCB-8380-7522C35E0006}.Xna|Any CPU.Build.0 = Xna|Any CPU
-		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Safe|Any CPU.ActiveCfg = Safe|Any CPU
-		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Safe|Any CPU.Build.0 = Safe|Any CPU
-		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.SafeX86|Any CPU.ActiveCfg = Safe|Any CPU
-		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Simd|Any CPU.ActiveCfg = Simd|Any CPU
-		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Simd|Any CPU.Build.0 = Simd|Any CPU
-		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Unsafe|Any CPU.ActiveCfg = Unsafe|Any CPU
-		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Unsafe|Any CPU.Build.0 = Unsafe|Any CPU
-		{DAC0541A-CB1C-44CA-BE7C-BF6CD5A8A9EE}.Xna|Any CPU.ActiveCfg = Safe|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.Safe|Any CPU.ActiveCfg = Release|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.Safe|Any CPU.Build.0 = Release|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.SafeX86|Any CPU.ActiveCfg = Release|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.SafeX86|Any CPU.Build.0 = Release|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.Simd|Any CPU.ActiveCfg = Release|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.Simd|Any CPU.Build.0 = Release|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.Unsafe|Any CPU.ActiveCfg = Release|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.Unsafe|Any CPU.Build.0 = Release|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.Xna|Any CPU.ActiveCfg = Release|Any CPU
+		{8C447CE8-3234-4F00-A88F-555656FB231E}.Xna|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = Benchmark\Benchmark.csproj

--- a/Mono.GameMath/Quaternion.cs
+++ b/Mono.GameMath/Quaternion.cs
@@ -535,7 +535,7 @@ namespace Mono.GameMath
 		
 		public bool Equals (Quaternion other)
 		{
-			return other == this;
+			return x.Equals(other.x) && y.Equals(other.y) && z.Equals(other.z) && w.Equals(other.w);
 		}
 		
 		public override bool Equals (object obj)
@@ -545,7 +545,7 @@ namespace Mono.GameMath
 		
 		public override int GetHashCode ()
 		{
-			return X.GetHashCode () ^ Y.GetHashCode () ^ Z.GetHashCode () ^ W.GetHashCode ();
+			return x.GetHashCode() * (31 * 31 * 31) + y.GetHashCode() * (31 * 31) + z.GetHashCode() * 31 + w.GetHashCode();
 		}
 		
 		public static bool operator == (Quaternion a, Quaternion b)

--- a/Mono.GameMath/Quaternion.cs
+++ b/Mono.GameMath/Quaternion.cs
@@ -163,6 +163,7 @@ namespace Mono.GameMath
 #if SIMD
 			result = new Quaternion (quaternion1.v4 + quaternion2.v4);
 #else
+			result = new Quaternion();
 			result.X = quaternion1.X + quaternion2.X;
 			result.Y = quaternion1.Y + quaternion2.Y;
 			result.Z = quaternion1.Z + quaternion2.Z;
@@ -185,6 +186,7 @@ namespace Mono.GameMath
 #if SIMD
 			result = new Quaternion (quaternion1.v4 - quaternion2.v4);
 #else
+			result = new Quaternion();
 			result.X = quaternion1.X - quaternion2.X;
 			result.Y = quaternion1.Y - quaternion2.Y;
 			result.Z = quaternion1.Z - quaternion2.Z;
@@ -205,6 +207,7 @@ namespace Mono.GameMath
 		public static void Multiply (ref Quaternion quaternion1, ref Quaternion quaternion2, out Quaternion result)
 		{
 			// TODO: SIMD optimization
+			result = new Quaternion();
 			result.X = quaternion1.W * quaternion2.X + quaternion1.X * quaternion2.W + quaternion1.Y * quaternion2.Z - quaternion1.Z * quaternion2.Y;
 			result.Y = quaternion1.W * quaternion2.Y - quaternion1.X * quaternion2.Z + quaternion1.Y * quaternion2.W + quaternion1.Z * quaternion2.X;
 			result.Z = quaternion1.W * quaternion2.Z + quaternion1.X * quaternion2.Y - quaternion1.Y * quaternion2.X + quaternion1.Z * quaternion2.W;
@@ -385,7 +388,8 @@ namespace Mono.GameMath
 		
 		public static void Conjugate (ref Quaternion value, out Quaternion result)
 		{
-			result.X = - value.X;
+			result = new Quaternion();
+			result.X = -value.X;
 			result.Y = - value.Y;
 			result.Z = - value.Z;
 			result.W = value.W;

--- a/Mono.GameMath/Vector2.cs
+++ b/Mono.GameMath/Vector2.cs
@@ -632,17 +632,17 @@ namespace Mono.GameMath
 		
 		public bool Equals (Vector2 other)
 		{
-			return x == other.x && y == other.y;
+			return x.Equals(other.x) && y.Equals(other.y);
 		}
 		
 		public override bool Equals (object obj)
 		{
-			return obj is Vector2 && ((Vector2)obj) == this;
+			return obj is Vector2 && this.Equals((Vector2)obj);
 		}
 		
 		public override int GetHashCode ()
 		{
-			return x.GetHashCode () ^ y.GetHashCode ();
+			return x.GetHashCode () * 31 + y.GetHashCode ();
 		}
 		
 		public static bool operator == (Vector2 a, Vector2 b)

--- a/Mono.GameMath/Vector3.cs
+++ b/Mono.GameMath/Vector3.cs
@@ -811,13 +811,13 @@ namespace Mono.GameMath
 #if SIMD
 			return v4 == other.v4;
 #else
-			return x == other.x && y == other.y && z == other.z;
+			return x.Equals(other.x) && y.Equals(other.y) && z.Equals(other.z);
 #endif
 		}
 		
 		public override bool Equals (object obj)
 		{
-			return obj is Vector3 && ((Vector3)obj) == this;
+			return obj is Vector3 && this.Equals((Vector2)obj);
 		}
 		
 		public override int GetHashCode ()
@@ -842,7 +842,7 @@ namespace Mono.GameMath
 			}
 			
 #else
-			return x.GetHashCode () ^ y.GetHashCode () ^ z.GetHashCode ();
+			return x.GetHashCode () * (31*31) + y.GetHashCode () * 31+ z.GetHashCode ();
 #endif
 		}
 		

--- a/Mono.GameMath/Vector4.cs
+++ b/Mono.GameMath/Vector4.cs
@@ -791,13 +791,13 @@ namespace Mono.GameMath
 #if SIMD
 			return v4 == other.v4;
 #else
-			return x == other.x && y == other.y && z == other.z && w == other.w;
+			return x.Equals(other.x) && y.Equals(other.y) && z.Equals(other.z) && w.Equals(other.w);
 #endif
 		}
 		
 		public override bool Equals (object obj)
 		{
-			return obj is Vector4 && ((Vector4)obj) == this;
+			return obj is Vector4 && this.Equals((Vector2)obj);
 		}
 		
 		public override int GetHashCode ()
@@ -824,7 +824,7 @@ namespace Mono.GameMath
 			}
 			
 #else
-			return x.GetHashCode () ^ y.GetHashCode () ^ w.GetHashCode () ^ w.GetHashCode ();
+			return x.GetHashCode () *(31*31*31) + y.GetHashCode () * (31*31) + z.GetHashCode () * 31 + w.GetHashCode ();
 #endif
 		}
 		


### PR DESCRIPTION
When compiling Quaternion.cs with VS2010 I get an error because the out parameter is not definitely assigned. This is because you only assign properties. I've added `result = new Quaternion()` where necessary.
I've added code fixing the quality problems in safe mode for Vector2, Vector3, Vector4 and Quaternion and added a unit tests to verify if equality behaves as expected.
